### PR TITLE
Add main README for OctoAcme project management documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# OctoAcme Project Management Docs
+
+Welcome! This directory documents how OctoAcme plans, executes, releases, tracks, and continuously improves cross-functional projects.
+
+## Project Management Processes at OctoAcme
+
+OctoAcme manages its projects with a structured yet flexible process designed to maximize clarity, collaboration, and delivery quality. Projects follow a clear lifecycle: Initiation, Planning, Execution & Tracking, Release & Deployment, and Retrospective & Continuous Improvement. Each phase is supported by concise checklists, templates, and regular check-in rituals to keep teams focused and responsive to challenges.
+
+Key roles include Project Managers (who coordinate schedules, risks, and team communication), Product Managers (responsible for vision, outcomes, and backlog prioritization), Developers (implementing, testing, and maintaining systems), and other stakeholders who provide input and approvals. The division of responsibilities ensures strong ownership and alignment, supported by meeting cadences like daily standups, weekly delivery syncs, and monthly stakeholder updates.
+
+OctoAcme values transparent and proactive communication. Status reports, risk registers, and demo reviews keep everyone up-to-date. Risks are tracked and escalated through clear paths from team triage to sponsor-level attention. The workflow centers on using project boards and PR conventions for clear traceability, while team rituals reinforce discipline and learning.
+
+For quality assurance, every project incorporates automated and manual testing, CI enforcement, security scanning, and release checklists. After every significant delivery, structured retrospectives are held to identify what worked and where improvements are needed—driving a culture of continuous improvement and higher team performance.
+
+## Documentation Index
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](./octoacme-roles-and-personas.md)
+
+## How to Use
+
+New and existing team members should start here to understand the OctoAcme approach to projects. For process improvements or clarifications, please open an issue using the process improvement template.


### PR DESCRIPTION
Adds a new README to the docs folder that provides:
- At-a-glance summary of OctoAcme project management processes
- Index and links to all process docs
- Orientation for new team members

Closes #2

Reviewer: @poh-am